### PR TITLE
Send batch requests to Social Graph Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ diagrams.js
 newrelic.js
 .env
 newrelic*
+aswcli-bundle

--- a/database/seedDatabase.js
+++ b/database/seedDatabase.js
@@ -1,4 +1,5 @@
 const cassandra = require('cassandra-driver');
+const axios = require('axios');
 
 const { client } = require('./index');
 const dataGeneration = require('./../server/helperFunctions/dataGeneration');
@@ -50,12 +51,12 @@ function createSingleInsert() {
 let batchNumber = 1
 
 function createBatchInsert() {
-  console.log('Data records: ', batchNumber * 50);
+  console.log('Data records: ', batchNumber * 100);
   batchNumber += 1;
 
   const queries = [];
 
-  for (let i = 0; i < 50; i++) {
+  for (let i = 0; i < 100; i++) {
     queries.push(createSingleInsert());
   }
 
@@ -63,7 +64,7 @@ function createBatchInsert() {
 }
 
 function createOneMillionEntries(int = 0) {
-  if (int === 200000) {
+  if (int === 1000000) {
     console.log('Creation complete');
     return;
   }
@@ -78,3 +79,12 @@ function createOneMillionEntries(int = 0) {
 
 // uncomment the below line to generate the data
 // createOneMillionEntries(0);
+
+// creates 1 feed request
+axios.post('http://127.0.0.1:3000/testinput')
+  .then((response) => {
+    console.log('Successful post');
+  })
+  .catch((err) => {
+    console.log('There was an error with the post');
+  });

--- a/server/helperFunctions/addIntsToDB.js
+++ b/server/helperFunctions/addIntsToDB.js
@@ -1,4 +1,4 @@
-const { client } = require('./../../database/index');
+const { client } = require('./../../database/index'); // THIS CLIENT WILL EVENTUALLY NEED TO LEAD TO MY EC2 INSTANCE
 const postIntsToTweets = require('./postIntsToTweets');
 
 const { generateIntrID, generateTimestamp } = require('./dataGeneration');

--- a/server/helperFunctions/createFriendQueryRequest.js
+++ b/server/helperFunctions/createFriendQueryRequest.js
@@ -19,19 +19,28 @@ module.exports = function createFriendQueryRequest(response, tweets) {
   // --- NEW WAY THAT SENDS 1 REQUEST TO AYGERIM FOR THE ENTIRE BATCH OF TWEETS -------------
   // create the array of tweets
   const arrayOfTweetIds = [];
+  const arrayOfIsAds = [];
 
   tweets.forEach((tweet, idx) => {
     arrayOfTweetIds.push(tweet.tweet_id);
+    arrayOfIsAds.push(tweet.isad);
   });
 
-  console.log('This is the array of TweetIds: ', arrayOfTweetIds);
-
-  return Promise.all(tweets.map((tweet) => {
-    return getFriendlyBoolean(response.data.user_id, tweet.tweet_id, tweet.isad)
-      .then((res) => {
-        return generateInteraction(response.data.user_id, tweet.tweet_id, tweet.isad, res.data);
-      });
-  }))
+  return getFriendlyBoolean(response.data.user_id, arrayOfTweetIds, arrayOfIsAds)
+    .then((res) => {
+      // creates an array of generateInteraction requests using the res object recieved back from Social Graph Service
+      return Promise.all(arrayOfTweetIds.map((tweetId, index) => {
+        return generateInteraction(response.data.user_id, tweetId, arrayOfIsAds[index], res.results[index]);
+      }))
+        .then((res) => {
+          return Promise.resolve();
+        })
+        .catch((err) => {
+          console.log('There was an error in generating interactions');
+          return Promise.reject();
+        })
+        // generateInteraction(response.data.user_id, tweet.tweet_id, tweet.isad, res.data);
+    })
     .catch((err) => {
       console.log('There was an error retreiving friend boolean: ', err);
       return Promise.reject();

--- a/server/helperFunctions/createFriendQueryRequest.js
+++ b/server/helperFunctions/createFriendQueryRequest.js
@@ -28,9 +28,9 @@ module.exports = function createFriendQueryRequest(response, tweets) {
 
   return getFriendlyBoolean(response.data.user_id, arrayOfTweetIds, arrayOfIsAds)
     .then((res) => {
-      // creates an array of generateInteraction requests using the res object recieved back from Social Graph Service
+      // creates an array of generateInteraction requests using res.data from Social Graph Service
       return Promise.all(arrayOfTweetIds.map((tweetId, index) => {
-        return generateInteraction(response.data.user_id, tweetId, arrayOfIsAds[index], res.results[index]);
+        return generateInteraction(response.data.user_id, tweetId, arrayOfIsAds[index], res.data.results[index]);
       }))
         .then((res) => {
           return Promise.resolve();

--- a/server/helperFunctions/createFriendQueryRequest.js
+++ b/server/helperFunctions/createFriendQueryRequest.js
@@ -3,6 +3,7 @@ const generateInteraction = require('./generateInteraction');
 
 // recursive function to create calls to Aygerim's service
 module.exports = function createFriendQueryRequest(response, tweets) {
+  // ---- THE BELOW IS AN OLD WAY THAT SENDS 1 REQUEST PER TWEET TO SOCIAL GRAPH SERVICE ----
   // returns an iterable array of request promises to Social Graph Service
   return Promise.all(tweets.map((tweet) => {
     return getFriendlyBoolean(response.data.user_id, tweet.tweet_id, tweet.isad)
@@ -14,4 +15,7 @@ module.exports = function createFriendQueryRequest(response, tweets) {
       console.log('There was an error retreiving friend boolean: ', err);
       return Promise.reject();
     });
+  // ----------------------------------------------------------------------------------------
+
+
 };

--- a/server/helperFunctions/createFriendQueryRequest.js
+++ b/server/helperFunctions/createFriendQueryRequest.js
@@ -5,6 +5,27 @@ const generateInteraction = require('./generateInteraction');
 module.exports = function createFriendQueryRequest(response, tweets) {
   // ---- THE BELOW IS AN OLD WAY THAT SENDS 1 REQUEST PER TWEET TO SOCIAL GRAPH SERVICE ----
   // returns an iterable array of request promises to Social Graph Service
+  // return Promise.all(tweets.map((tweet) => {
+  //   return getFriendlyBoolean(response.data.user_id, tweet.tweet_id, tweet.isad)
+  //     .then((res) => {
+  //       return generateInteraction(response.data.user_id, tweet.tweet_id, tweet.isad, res.data);
+  //     });
+  // }))
+  //   .catch((err) => {
+  //     console.log('There was an error retreiving friend boolean: ', err);
+  //     return Promise.reject();
+  //   });
+  // ----------------------------------------------------------------------------------------
+  // --- NEW WAY THAT SENDS 1 REQUEST TO AYGERIM FOR THE ENTIRE BATCH OF TWEETS -------------
+  // create the array of tweets
+  const arrayOfTweetIds = [];
+
+  tweets.forEach((tweet, idx) => {
+    arrayOfTweetIds.push(tweet.tweet_id);
+  });
+
+  console.log('This is the array of TweetIds: ', arrayOfTweetIds);
+
   return Promise.all(tweets.map((tweet) => {
     return getFriendlyBoolean(response.data.user_id, tweet.tweet_id, tweet.isad)
       .then((res) => {
@@ -15,7 +36,4 @@ module.exports = function createFriendQueryRequest(response, tweets) {
       console.log('There was an error retreiving friend boolean: ', err);
       return Promise.reject();
     });
-  // ----------------------------------------------------------------------------------------
-
-
 };

--- a/server/helperFunctions/getFeed.js
+++ b/server/helperFunctions/getFeed.js
@@ -6,8 +6,8 @@ const createFriendQueryRequests = require('./createFriendQueryRequest');
 const getFeed = () => {
   const user = generateUserID();
 
-  return axios.get(`http://127.0.0.1:3000/feed/${user}`)
-    .then((response) => {
+  return axios.get(`http://127.0.0.1:3000/feed/${user}`) // WILL EVENTUALLY ADD JUN'S SERVICE HERE
+    .then((response) => { // If i get a proper response from feeds
       console.log('Successfuly got feed object: ', response.data);
       const { tweets } = response.data;
 

--- a/server/helperFunctions/getFriendlyBoolean.js
+++ b/server/helperFunctions/getFriendlyBoolean.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 
-const getFriendlyBoolean = (userId, arrayOfTweetIds, isAd) => {
+const getFriendlyBoolean = (userId, arrayOfTweetIds, arrayOfIsAds) => {
   return axios.get('http://127.0.0.1:3000/user', { // WILL PUT AYGERIM'S SERVICE HERE
     params: {
       user_id: userId,

--- a/server/helperFunctions/getFriendlyBoolean.js
+++ b/server/helperFunctions/getFriendlyBoolean.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 
 const getFriendlyBoolean = (userId, tweetId, isAd) => {
-  return axios.get('http://127.0.0.1:3000/user', {
+  return axios.get('http://127.0.0.1:3000/user', { // WILL PUT AYGERIM'S SERVICE HERE
     params: {
       user_id: userId,
       tweet_id: tweetId, // literally turns into http://127.0.0.1:3000/user?user_id=userId&tweet_id=tweetId

--- a/server/helperFunctions/getFriendlyBoolean.js
+++ b/server/helperFunctions/getFriendlyBoolean.js
@@ -1,10 +1,10 @@
 const axios = require('axios');
 
-const getFriendlyBoolean = (userId, tweetId, isAd) => {
+const getFriendlyBoolean = (userId, arrayOfTweetIds, isAd) => {
   return axios.get('http://127.0.0.1:3000/user', { // WILL PUT AYGERIM'S SERVICE HERE
     params: {
       user_id: userId,
-      tweet_id: tweetId, // literally turns into http://127.0.0.1:3000/user?user_id=userId&tweet_id=tweetId
+      tweet_ids: arrayOfTweetIds, // literally turns into http://127.0.0.1:3000/user?user_id=userId&tweet_id=tweetId
     },
   }); // TODO: change this to Aygerim's actual service
 };

--- a/server/helperFunctions/postIntsToTweets.js
+++ b/server/helperFunctions/postIntsToTweets.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 
 const postIntsToTweets = (userId, tweetId) => {
-  return axios.post('http://127.0.0.1:3000/tweets/events', { // TODO: change this to connect with Nick's service
+  return axios.post('http://127.0.0.1:3000/tweets/events', { // TODO: CHANGE THIS TO CONNECT WITH NICK'S SERVICE
     user_id: userId,
     tweet_id: tweetId,
   })

--- a/server/index.js
+++ b/server/index.js
@@ -23,12 +23,12 @@ app.get('/', (request, response) => {
   response.send('-v mounts a volume on the CONTAINER - no change is needed on the actual image... Also, I dont even have nodemon running... jk, nodemon IS RUNNING');
 });
 
-app.post('/tweets/events', (request, response) => {
+app.post('/tweets/events', (request, response) => { // will be to Nick's service
   console.log('Post to tweets successful');
   response.json();
 });
 
-app.get('/user', (request, response) => {
+app.get('/user', (request, response) => { // will be to Aygerm
   console.log('Get to /user successful');
   response.json(!!Math.round(Math.random()));
 });

--- a/server/index.js
+++ b/server/index.js
@@ -30,7 +30,7 @@ app.post('/tweets/events', (request, response) => { // will be to Nick's service
 
 app.get('/user', (request, response) => { // will be to Aygerm
   console.log('Get to /user successful');
-  response.json(!!Math.round(Math.random()));
+  response.json({ results: [true, false, false, true, true] });
 });
 
 app.get('/feed/:userId', (request, response) => {


### PR DESCRIPTION
Hey Team,

This pull request is updated so that batch requests can be sent to Aygerim's service and a response object with an array of booleans is received and processed correctly.

Interactions are still generated randomly and (in contrast to what we discussed as a group) will be sent to Nick's Tweet Service as they always have been: one at a time.

